### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/test/z.fish
+++ b/test/z.fish
@@ -1,1 +1,1 @@
-test available z
+test type -q z


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
