### PR TITLE
Prefix `cd` with builtin.

### DIFF
--- a/functions/z.fish
+++ b/functions/z.fish
@@ -5,5 +5,6 @@
 #   Options
 #
 function z -d "jump around"
-  builtin cd (bash -c "source $Z_SCRIPT_PATH; _z $argv; echo \$PWD")
+  set -l escaped (echo $argv | sed -E "s/\'/\\\'/g")
+  builtin cd (bash -c "source $Z_SCRIPT_PATH; _z $escaped; echo \$PWD")
 end

--- a/functions/z.fish
+++ b/functions/z.fish
@@ -5,5 +5,5 @@
 #   Options
 #
 function z -d "jump around"
-  cd (bash -c "source $Z_SCRIPT_PATH; _z $argv; echo \$PWD")
+  builtin cd (bash -c "source $Z_SCRIPT_PATH; _z $argv; echo \$PWD")
 end


### PR DESCRIPTION
Allows you to alias cd to z without causing an infinite loop.