### PR TITLE
Use fish cd function instead of builtin

### DIFF
--- a/functions/z.fish
+++ b/functions/z.fish
@@ -13,7 +13,7 @@ function z -d "jump around"
 
   # If z changed directories, reflect that in the current process.
   if test $Z_PWD != $PWD
-    builtin cd $Z_PWD
+    cd $Z_PWD
   end
 
   return $Z_STATUS


### PR DESCRIPTION
Using the builtin `cd` doesn't add directories to fish's history, which renders the `cdh` command useless.

Note that I haven't tested this thoroughly, but it seems to work.