### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/functions/z.fish
+++ b/functions/z.fish
@@ -8,7 +8,7 @@ function z -d "jump around"
     Z_STATUS=$?
     echo "$PWD" >&2
     exit $Z_STATUS
-  ' bash $argv ^| read -l Z_PWD
+  ' bash $argv 2>| read -l Z_PWD
   set -l Z_STATUS $status
 
   # If z changed directories, reflect that in the current process.


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618